### PR TITLE
fixes naming bug [#159761405 Fixes]

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -63,7 +63,7 @@ def bad_request(error):
 
 
 @app.errorhandler(409)
-def bad_request(error):
+def question_exist(error):
     '''
     Conflicting request, question exist
     Args:


### PR DESCRIPTION
I had named conflict error handler differently, i will go ahead and merge as there is nothing really big here
@leni1
@Eubule
@jeanjoe
@araaliFarooq